### PR TITLE
Encoded query string and attributes

### DIFF
--- a/PortableRazor/HtmlHelper.cs
+++ b/PortableRazor/HtmlHelper.cs
@@ -20,8 +20,11 @@ namespace PortableRazor.Web.Mvc
 		private string GenerateHtmlAttributes(object htmlAttributes) {
 			var attrs = new StringBuilder ();
 			if (htmlAttributes != null) {
-				foreach (var property in htmlAttributes.GetType ().GetRuntimeProperties()) 
-					attrs.AppendFormat (@" {0}=""{1}""", property.Name.Replace('_', '-'), property.GetMethod.Invoke (htmlAttributes, null));
+                foreach (var property in htmlAttributes.GetType().GetRuntimeProperties())
+                {
+                    string htmlEncodedValue = System.Net.WebUtility.HtmlEncode(property.GetMethod.Invoke(htmlAttributes, null).ToString());
+                    attrs.AppendFormat(@" {0}=""{1}""", property.Name.Replace('_', '-'), htmlEncodedValue);
+                }
 			}
 			return attrs.ToString ();
 		}

--- a/PortableRazor/UrlHelper.cs
+++ b/PortableRazor/UrlHelper.cs
@@ -52,10 +52,14 @@ namespace PortableRazor.Web.Mvc
 				return String.Empty;
 
 			var qs = new StringBuilder ();
-			foreach (var property in routeValues.GetType ().GetRuntimeProperties()) 
-				qs.AppendFormat ("&{0}={1}", property.Name, property.GetMethod.Invoke (routeValues, null));
+			foreach (var property in routeValues.GetType ().GetRuntimeProperties())
+            {
+                string urlEncodedValue = System.Net.WebUtility.UrlEncode(property.GetMethod.Invoke(routeValues, null).ToString());
+                qs.AppendFormat("&{0}={1}", property.Name, urlEncodedValue);
 
-			if (qs.Length == 0)
+            }
+
+            if (qs.Length == 0)
 				return String.Empty;
 
 			return qs.ToString (1, qs.Length - 1);


### PR DESCRIPTION
Fixed a discrepancy between MVC and Portable razor where the query
string parameters and the attributes were not encoded when passed as an
anonymous type
