### PR TITLE
Beginnings of ASP.NET MVC InputExtensions, ViewBag, Model Binding Support

### DIFF
--- a/PortableRazor.Web/MvcHtmlString.cs
+++ b/PortableRazor.Web/MvcHtmlString.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PortableRazor.Web.Mvc
+{
+    public class MvcHtmlString : HtmlString
+    {
+        protected string value;
+
+        public MvcHtmlString(string value) : base(value)
+        {
+            this.value = value;
+        }
+        
+        public static bool IsNullOrEmpty(MvcHtmlString value)
+        {
+            return String.IsNullOrEmpty(value.value);
+        }
+
+    }
+}

--- a/PortableRazor.Web/ViewBagObject.cs
+++ b/PortableRazor.Web/ViewBagObject.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PortableRazor.Web.Mvc
+{
+    /// <summary>
+    /// Represents ASP.NET MVC ViewBag Dynamic Object
+    /// </summary>
+    public class ViewBagObject : DynamicObject
+    {
+        private readonly Dictionary<string, object> values
+            = new Dictionary<string, object>();
+
+        public override bool TryGetMember(GetMemberBinder binder, out object result)
+        {
+            values.TryGetValue(binder.Name, out result);
+            return true;
+        }
+
+        public override bool TrySetMember(SetMemberBinder binder, object value)
+        {
+            values[binder.Name] = value;
+            return true;
+        }
+    }
+}

--- a/PortableRazor.csproj
+++ b/PortableRazor.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -30,7 +30,13 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="PortableRazor.Web\MvcHtmlString.cs" />
+    <Compile Include="PortableRazor.Web\ViewBagObject.cs" />
+    <Compile Include="PortableRazor\HtmlHelper.InputFor.cs" />
+    <Compile Include="PortableRazor\HtmlHelper.LabelFor.cs" />
+    <Compile Include="PortableRazor\HtmlHelper.TextAreaFor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReflectionHelper.cs" />
     <Compile Include="ViewBase.cs" />
     <Compile Include="IHybridWebView.cs" />
     <Compile Include="PortableRazor\HtmlHelper.Form.cs" />
@@ -47,8 +53,4 @@
     <Compile Include="RouteHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <ItemGroup>
-    <Folder Include="PortableRazor\" />
-    <Folder Include="PortableRazor.Web\" />
-  </ItemGroup>
 </Project>

--- a/PortableRazor/HtmlHelper.Form.cs
+++ b/PortableRazor/HtmlHelper.Form.cs
@@ -25,6 +25,20 @@ namespace PortableRazor.Web.Mvc
 			_writer.Write (form);
 			return new MvcForm (_writer, "form");
 		}
+
+        public MvcForm BeginForm(string actionName, string controllerName, PortableRazor.ViewBase.FormMethod method, object htmlAttributes = null)
+        {
+            switch (method)
+            {
+                case PortableRazor.ViewBase.FormMethod.Post:
+                    return BeginForm(actionName, controllerName, null, FormMethod.Post, htmlAttributes);
+                    break;
+                case PortableRazor.ViewBase.FormMethod.Get:
+                default:
+                    return BeginForm(actionName, controllerName, null, FormMethod.Get, htmlAttributes);
+                    break;
+            }
+        }
 	}
 }
 

--- a/PortableRazor/HtmlHelper.InputFor.cs
+++ b/PortableRazor/HtmlHelper.InputFor.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PortableRazor.Web.Mvc
+{
+    public partial class HtmlHelper
+    {
+        #region Checkbox
+        public IHtmlString CheckBoxFor(Func<dynamic, dynamic> func, string name = "")
+        {
+            // TODO figure out how to get name out of Func<dynamic, dynamic>
+            // Can't get it with Expression<Func<dynamic, dynamic>>
+            // var name = "";
+            var result = func.Invoke(Model);
+            return InputFor("checkbox", isChecked: result, name: name);
+        }
+
+        public IHtmlString CheckBoxFor(Func<dynamic, dynamic> func, IDictionary<String, object> htmlAttributes, string name = "")
+        {
+            // TODO figure out how to get name out of Func<dynamic, dynamic>
+            // Can't get it with Expression<Func<dynamic, dynamic>>
+            // var name = "";
+            var result = func.Invoke(Model);
+            return InputFor("checkbox", isChecked: result, htmlAttributes: UrlHelper.GetObjectFromDict(htmlAttributes), name: name);
+        }
+        
+        public IHtmlString CheckBoxFor(Func<dynamic, dynamic> func, object htmlAttributes, string name = "")
+        {
+            // TODO figure out how to get name out of Func<dynamic, dynamic>
+            // Can't get it with Expression<Func<dynamic, dynamic>>
+            // var name = "";
+            var result = func.Invoke(Model);
+            return InputFor("checkbox", isChecked: result, htmlAttributes: htmlAttributes, name: name);
+        }
+        #endregion
+
+        #region Hidden
+        public IHtmlString HiddenFor(Func<dynamic, dynamic> func, string name = "")
+        {
+            // TODO figure out how to get name out of Func<dynamic, dynamic>
+            // Can't get it with Expression<Func<dynamic, dynamic>>
+            // var name = "";
+            var result = func.Invoke(Model);
+            return InputFor("checkbox", result, name: name);
+        }
+
+        public IHtmlString HiddenFor(Func<dynamic, dynamic> func, IDictionary<String, object> htmlAttributes, string name = "")
+        {
+            // TODO figure out how to get name out of Func<dynamic, dynamic>
+            // Can't get it with Expression<Func<dynamic, dynamic>>
+            // var name = "";
+            var result = func.Invoke(Model);
+            return InputFor("checkbox", func.Invoke(Model), htmlAttributes: UrlHelper.GetObjectFromDict(htmlAttributes), name: name);
+        }
+
+        public IHtmlString HiddenFor(Func<dynamic, dynamic> func, object htmlAttributes, string name = "")
+        {
+            // TODO figure out how to get name out of Func<dynamic, dynamic>
+            // Can't get it with Expression<Func<dynamic, dynamic>>
+            // var name = "";
+            var result = func.Invoke(Model);
+            return InputFor("checkbox", result, htmlAttributes: htmlAttributes, name: name);
+        }
+        #endregion
+
+        #region Password
+        public IHtmlString PasswordFor(Func<dynamic, dynamic> func, string name = "")
+        {
+            // TODO figure out how to get name out of Func<dynamic, dynamic>
+            // Can't get it with Expression<Func<dynamic, dynamic>>
+            // var name = "";
+            var result = func.Invoke(Model);
+            return InputFor("password", result, name: name);
+        }
+
+        public IHtmlString PasswordFor(Func<dynamic, dynamic> func, IDictionary<String, object> htmlAttributes, string name = "")
+        {
+            // TODO figure out how to get name out of Func<dynamic, dynamic>
+            // Can't get it with Expression<Func<dynamic, dynamic>>
+            // var name = "";
+            var result = func.Invoke(Model);
+            return InputFor("password", result, htmlAttributes: UrlHelper.GetObjectFromDict(htmlAttributes), name: name);
+        }
+
+        public IHtmlString PasswordFor(Func<dynamic, dynamic> func, object htmlAttributes, string name = "")
+        {
+            // TODO figure out how to get name out of Func<dynamic, dynamic>
+            // Can't get it with Expression<Func<dynamic, dynamic>>
+            // var name = "";
+            var result = func.Invoke(Model);
+            return InputFor("password", result, htmlAttributes: htmlAttributes, name: name);
+        }
+        #endregion
+
+        #region RadioButton
+        public IHtmlString RadioButtonFor(Func<dynamic, dynamic> func, string name = "")
+        {
+            // TODO figure out how to get name out of Func<dynamic, dynamic>
+            // Can't get it with Expression<Func<dynamic, dynamic>>
+            // var name = "";
+            var result = func.Invoke(Model);
+            return InputFor("radio", result, name: name);
+        }
+
+        public IHtmlString RadioButtonFor(Func<dynamic, dynamic> func, IDictionary<String, object> htmlAttributes, string name = "")
+        {
+            // TODO figure out how to get name out of Func<dynamic, dynamic>
+            // Can't get it with Expression<Func<dynamic, dynamic>>
+            // var name = "";
+            var result = func.Invoke(Model);
+            return InputFor("radio", result, htmlAttributes: UrlHelper.GetObjectFromDict(htmlAttributes), name: name);
+        }
+
+        public IHtmlString RadioButtonFor(Func<dynamic, dynamic> func, object htmlAttributes, string name = "")
+        {
+            // TODO figure out how to get name out of Func<dynamic, dynamic>
+            // Can't get it with Expression<Func<dynamic, dynamic>>
+            // var name = "";
+            var result = func.Invoke(Model);
+            return InputFor("radio", result, htmlAttributes: htmlAttributes, name: name);
+        }
+        #endregion
+
+        #region TextBox
+        public IHtmlString TextBoxFor(Func<dynamic, dynamic> func, string name = "")
+        {
+            // TODO figure out how to get name out of Func<dynamic, dynamic>
+            // Can't get it with Expression<Func<dynamic, dynamic>>
+            // var name = "";
+            var result = func.Invoke(Model);
+            return InputFor("text", result, name: name);
+        }
+
+        public IHtmlString TextBoxFor(Func<dynamic, dynamic> func, IDictionary<String, object> htmlAttributes, string name = "")
+        {
+            // TODO figure out how to get name out of Func<dynamic, dynamic>
+            // Can't get it with Expression<Func<dynamic, dynamic>>
+            // var name = "";
+            var result = func.Invoke(Model);
+            return InputFor("text", result, htmlAttributes: UrlHelper.GetObjectFromDict(htmlAttributes), name: name);
+        }
+
+        public IHtmlString TextBoxFor(Func<dynamic, dynamic> func, object htmlAttributes, string name = "")
+        {
+            // TODO figure out how to get name out of Func<dynamic, dynamic>
+            // Can't get it with Expression<Func<dynamic, dynamic>>
+            // var name = "";
+            var result = func.Invoke(Model);
+            return InputFor("text", result, htmlAttributes: htmlAttributes, name: name);
+        }
+
+        #endregion
+
+        public IHtmlString InputFor(string inputType, object value = null, string format = "{0}", object htmlAttributes = null, bool isChecked = false, string name = "")
+        {
+            var formattedValue = value != null ? String.Format(format, value) : null;
+            // TODO figure out how to render name dynamically
+            // Right now "name" and "id" must be part of the htmlAttributes
+            if (!string.IsNullOrEmpty(name))
+            {
+                return new MvcHtmlString(string.Format("<input type=\"{0}\" name=\"{1}\" {2}{3}{4} />",
+                    inputType,
+                    name,
+                    formattedValue == null ? String.Empty : String.Format("value=\"{0}\"", formattedValue),
+                    isChecked ? " checked=\"checked\"" : String.Empty,
+                    GenerateHtmlAttributes(htmlAttributes)));
+            }
+            else
+            {
+                return new MvcHtmlString(string.Format("<input type=\"{0}\" {1}{2}{3} />",
+                    inputType,
+                    formattedValue == null ? String.Empty : String.Format("value=\"{0}\"", formattedValue),
+                    isChecked ? " checked=\"checked\"" : String.Empty,
+                    GenerateHtmlAttributes(htmlAttributes)));
+            }
+        }
+
+    }
+}

--- a/PortableRazor/HtmlHelper.LabelFor.cs
+++ b/PortableRazor/HtmlHelper.LabelFor.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PortableRazor.Web.Mvc
+{
+    public partial class HtmlHelper
+    {
+
+        public IHtmlString LabelFor(Func<dynamic, dynamic> expression, object htmlAttributes = null, string name = "", string label = "")
+        {
+            // TODO figure out how to get name out of System.ComponentModel.DataAnnotations
+            return LabelFor(label, name, htmlAttributes: htmlAttributes);
+        }
+
+        public IHtmlString LabelFor(string labelText, string labelFor = "", object htmlAttributes = null)
+        {
+            return new MvcHtmlString(string.Format("<label for=\"{0}\"{1}>{2}</label>",
+                labelFor,
+                GenerateHtmlAttributes(htmlAttributes),
+                labelText));
+        }
+
+    }
+}

--- a/PortableRazor/HtmlHelper.TextArea.cs
+++ b/PortableRazor/HtmlHelper.TextArea.cs
@@ -17,7 +17,7 @@ namespace PortableRazor.Web.Mvc
 		}
 
 		public IHtmlString TextArea(string name, string value = "", int rows = -1, int columns = -1, object htmlAttributes = null){
-			return new HtmlString (string.Format ("<textarea name=\"{1}\" id=\"{1}\"{2}{3}{4}>{0}</textarea>", 
+			return new HtmlString(string.Format ("<textarea name=\"{1}\" id=\"{1}\"{2}{3}{4}>{0}</textarea>", 
 				value,
 				name,
 				rows > -1 ? String.Format ("rows=\"{0}\"", rows) : String.Empty,

--- a/PortableRazor/HtmlHelper.TextAreaFor.cs
+++ b/PortableRazor/HtmlHelper.TextAreaFor.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PortableRazor.Web.Mvc
+{
+    public partial class HtmlHelper
+    {
+        public IHtmlString TextAreaFor(Func<dynamic, dynamic> func, object htmlAttributes = null, string name = "")
+        {
+            // TODO figure out how to get name out of Func<dynamic, dynamic>
+            // Can't get it with Expression<Func<dynamic, dynamic>>
+            // var name = "";
+            var result = func.Invoke(Model);
+            return TextAreaFor(name, result, htmlAttributes: htmlAttributes);
+        }
+        
+        public IHtmlString TextAreaFor(string name, string value = "", int rows = -1, int columns = -1, object htmlAttributes = null)
+        {
+            return new HtmlString(string.Format("<textarea name=\"{1}\" id=\"{1}\"{2}{3}{4}>{0}</textarea>",
+                value,
+                name,
+                rows > -1 ? String.Format("rows=\"{0}\"", rows) : String.Empty,
+                columns > -1 ? String.Format("cols=\"{0}\"", columns) : String.Empty,
+                GenerateHtmlAttributes(htmlAttributes)));
+        }
+    }
+}

--- a/PortableRazor/HtmlHelper.cs
+++ b/PortableRazor/HtmlHelper.cs
@@ -9,6 +9,19 @@ namespace PortableRazor.Web.Mvc
 	public partial class HtmlHelper {
 		private TextWriter _writer;
 
+        private dynamic _model;
+        public dynamic Model
+        {
+            get
+            {
+                return this._model;
+            }
+            set
+            {
+                this._model = value;
+            }
+        }
+
 		public HtmlHelper(TextWriter writer) {
 			_writer = writer;
 		}

--- a/PortableRazor/UrlHelper.cs
+++ b/PortableRazor/UrlHelper.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 
@@ -60,6 +63,24 @@ namespace PortableRazor.Web.Mvc
 
 			return qs.ToString (1, qs.Length - 1);
 		}
+
+        /// <summary>
+        /// http://stackoverflow.com/a/7596697
+        /// </summary>
+        /// <param name="dict"></param>
+        /// <returns></returns>
+        public static object GetObjectFromDict(IDictionary<string, object> dict)
+        {
+            var eo = new ExpandoObject();
+            var eoColl = (ICollection<KeyValuePair<string, object>>)eo;
+            foreach (var kvp in dict)
+            {
+                eoColl.Add(kvp);
+            }
+            dynamic eoDynamic = eo;
+            return eoDynamic.Property;
+        }
+        
 	}
 }
 

--- a/ReflectionHelper.cs
+++ b/ReflectionHelper.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PortableRazor
+{
+    /// <summary>
+    /// See http://stackoverflow.com/questions/13270183/type-conversion-issue-when-setting-property-through-reflection
+    /// </summary>
+    static class ReflectionHelper
+    {
+        public static void SetValueNullable(this PropertyInfo obj, object inputObject, string propertyName, object propertyVal)
+        {
+            //find out the type
+            Type type = inputObject.GetType();
+
+            //get the property information based on the type
+            System.Reflection.PropertyInfo propertyInfo = type.GetRuntimeProperty(propertyName);
+
+            //find the property type
+            Type propertyType = propertyInfo.PropertyType;
+
+            //Convert.ChangeType does not handle conversion to nullable types
+            //if the property type is nullable, we need to get the underlying type of the property
+            var targetType = IsNullableType(propertyInfo.PropertyType) ? Nullable.GetUnderlyingType(propertyInfo.PropertyType) : propertyInfo.PropertyType;
+
+            //Returns an System.Object with the specified System.Type and whose value is
+            //equivalent to the specified object.
+            propertyVal = Convert.ChangeType(propertyVal, targetType);
+
+            //Set the value of the property
+            propertyInfo.SetValue(inputObject, propertyVal, null);
+
+        }
+        private static bool IsNullableType(Type type)
+        {
+            return type.IsGenericParameter && type.GetGenericTypeDefinition().Equals(typeof(Nullable<>));
+        }
+    }
+}

--- a/ViewBase.cs
+++ b/ViewBase.cs
@@ -1,21 +1,51 @@
-using System;
+﻿using System;
 using PortableRazor.Web;
 using PortableRazor.Web.Mvc;
+using System.Dynamic;
 
 namespace PortableRazor
 {
 	//This was copied from the generated .cs for one of the razor views
 	public abstract class ViewBase
 	{
-		private static string scheme;
+        /// <summary>
+        /// Note that Android does not currently support POST Body in IHybridWebView
+        /// See https://code.google.com/p/android/issues/detail?id=42790​
+        /// Therefore, POST requests must be encoded in the URL in the HTML
+        /// </summary>
+        public enum FormMethod
+        {
+            Get,
+            Post
+        }
+
+        private static string scheme;
 		public static string UrlScheme {
 			get { return scheme ?? "hybrid:"; }
 			set { scheme = value; }
 		}
 
-		public HtmlHelper Html { get; private set; }
+		public HtmlHelper Html { get; set; }
 
 		public UrlHelper Url { get; private set; }
+
+        /// <summary>
+        /// MVC Layout Definition
+        /// </summary>
+        public string Layout { get; set; }
+
+        /// <summary>
+        /// MVC ViewBag Definition
+        /// </summary>
+        protected dynamic _ViewBag;
+        public dynamic ViewBag
+        {
+            get
+            {
+                if (_ViewBag == null) _ViewBag = new ViewBagObject();
+                return _ViewBag;
+            }
+        }
 
 		// This field is OPTIONAL, but used by the default implementation of Generate, Write, WriteAttribute and WriteLiteral
 		//


### PR DESCRIPTION
This is the beginning of ASP.NET MVC InputExtensions Support

I have stubbed the following controls
- CheckboxFor
- HiddenFor
- PasswordFor
- RadioButtonFor
- TextBoxFor
- InputFor
- LabelFor
  +
  Support for ViewBag using custom ExpandoObject implementation
  and dynamic mapping / binding of data models to controller rather than manual mapping

Unfortunately, I have not been able to pull the name off a `Func<dynamic, dynamic>` since I need an `Expression<Func<TModel, TProperty>>` (no dynamic) so I cannot set the "name" property of the HTML controls yet. Luckily, Microsoft's InputExtensions provides a reference for when I do this in the future.

This will allow users to simply **"cut and paste" basic ASP.NET MVC views**, with the addition of one extra line they can use automatic model binding (see below for the caveat)

``` C#
@inherits PortableRazor.ViewBase
@model Namespace.Model
@{ Html.Model = Model; }
```

Currently, the "XXXFor" methods must be passed the html attribute @name in order to render the name attribute. So for example, 

``` C#
@Html.CheckBoxFor(m => m.RememberMe, new { @name = "RememberMe", })
```

Still, better than no InputExtensions support at all!

Then, you can write controllers with all the automatic binding goodness that is MVC

public void ControllerMethod(ModelType model)
{
   // Properties should be bound from GET parameters!
}

Note that HybridWebView does not currently support POST (see following Android issue https://code.google.com/p/android/issues/detail?id=42790​) so I have stubbed POST support, but the mapping is pulled from query string parameters.

Regards,
~ B
